### PR TITLE
chore: extend .gitignore with editor and local env entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,13 @@ build/
 # Local/Gemini
 .gemini/
 docs/superpowers/
+
+# Local dev
+*.log
+.DS_Store
+.env.local
+.env.*.local
+
+# Editor
+.vscode/
+.idea/


### PR DESCRIPTION
Prevents .DS_Store, local env files, and editor config from being committed.