### PR TITLE
fix(content): update bio, email, hide testimonials

### DIFF
--- a/content.json
+++ b/content.json
@@ -8,7 +8,7 @@
       "Finance Engineer",
       "Product Builder"
     ],
-    "bio": "I sit at the intersection of financial logic and AI engineering. Four years in accounting and finance taught me where spreadsheets break down and where data lies. Now I build the tools that replace them.",
+    "bio": "I started in accounting, ended up building AI systems. Four years of finance operations taught me where data breaks and why it matters. Now I ship full-stack apps, ML pipelines, and whatever the problem calls for. TypeScript, Python, React, FastAPI — generalist by design.",
     "avatarUrl": "",
     "avatarFallback": "BS"
   },
@@ -28,7 +28,7 @@
     "experience": true,
     "education": true,
     "techStack": true,
-    "testimonials": true,
+    "testimonials": false,
     "writing": false,
     "contact": true,
     "game": true
@@ -55,8 +55,8 @@
       "Finance Engineer",
       "Product Builder"
     ],
-    "bio": "I sit at the intersection of financial logic and AI engineering. Four years in accounting and finance taught me where spreadsheets break down and where data lies. Now I build the tools that replace them.",
-    "email": "basilsuhailkhan@gmail.com",
+    "bio": "I started in accounting, ended up building AI systems. Four years of finance operations taught me where data breaks and why it matters. Now I ship full-stack apps, ML pipelines, and whatever the problem calls for. TypeScript, Python, React, FastAPI — generalist by design.",
+    "email": "basilsuhail3@gmail.com",
     "avatarUrl": "/uploads/headshot.png",
     "avatarFallback": "BS"
   },


### PR DESCRIPTION
## Summary
- Rewrote hero bio to generalist narrative (works for both freelance clients and recruiters)
- Updated contact email from `basilsuhailkhan@gmail.com` → `basilsuhail3@gmail.com`
- Set `sectionVisibility.testimonials: false` so git-based redeploys on Dokploy don't re-enable the section

## Root cause note
Admin UI changes to `content.json` survive container restarts (volume mount) but NOT Dokploy redeploys, which git-pull and overwrite the file. Fix: keep committed state correct.

## Test plan
- [ ] Hero bio shows new text on localhost
- [ ] Email shows `basilsuhail3@gmail.com` in contact section
- [ ] Testimonials section hidden on homepage
- [ ] Admin toggle still works at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)